### PR TITLE
Use FrontendResponse in StorageController

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/api/FrontEndResponse.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/FrontEndResponse.kt
@@ -1,0 +1,8 @@
+package no.nav.eessi.pensjon.api
+
+data class FrontEndResponse<T>(
+    val result: T? = null,
+    val status: String? = null,
+    val message: String? = null,
+    val stackTrace: String? = null
+)

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -63,7 +63,7 @@ class StorageController(private val storage: GcpStorageService,
 
     @EessiPensjonTilgang
     @Timed("s3.get")
-    @GetMapping(value = ["/get/{path}"])
+    @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<String>> {
         return getDocument.measure {
             return@measure try {

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -63,7 +63,7 @@ class StorageController(private val storage: GcpStorageService,
 
     @EessiPensjonTilgang
     @Timed("s3.get")
-    @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping(value = ["/get/{path}"])
     fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<String>> {
         return getDocument.measure {
             return@measure try {

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -1,14 +1,12 @@
 package no.nav.eessi.pensjon.api.storage
 
 import com.google.cloud.storage.StorageException
-import com.fasterxml.jackson.databind.JsonNode
 import io.micrometer.core.annotation.Timed
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.eessi.pensjon.api.FrontEndResponse
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.services.auth.EessiPensjonTilgang
-import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.maskerPersonIdentifier
 import no.nav.security.token.support.core.api.Protected
 import org.slf4j.LoggerFactory
@@ -17,7 +15,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.util.*
 
 @Protected
 @RestController
@@ -67,12 +64,12 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.get")
     @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<JsonNode>> {
+    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<String>> {
         return getDocument.measure {
             return@measure try {
                 validerPath(path)
                 logger.info("Henter S3 dokument")
-                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path)?.let { mapJsonToAny<JsonNode>(it) }, status = HttpStatus.OK.name))
+                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path), status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
                 val status = HttpStatus.valueOf(gcpEx.code)
                 ResponseEntity.status(status).body(

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -1,6 +1,7 @@
 package no.nav.eessi.pensjon.api.storage
 
 import com.google.cloud.storage.StorageException
+import com.fasterxml.jackson.databind.JsonNode
 import io.micrometer.core.annotation.Timed
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.eessi.pensjon.api.FrontEndResponse
@@ -44,12 +45,12 @@ class StorageController(private val storage: GcpStorageService,
     @Timed("s3.put")
     @PostMapping("/{path}")
     fun storeDocument(@PathVariable(required = true) path: String,
-                      @RequestBody(required = true) document: String): ResponseEntity<FrontEndResponse<Unit>> {
+                      @RequestBody(required = true) document: String): ResponseEntity<FrontEndResponse<Boolean>> {
         return storeDocument.measure {
             return@measure try {
                 validerPath(path)
                 storage.lagre(path, document).also { logger.info("Lagrer dokument for frontend: $path") }
-                ResponseEntity.ok(FrontEndResponse(status = HttpStatus.OK.name))
+                ResponseEntity.ok(FrontEndResponse(result = true, status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
                 val status = HttpStatus.valueOf(gcpEx.code)
                 ResponseEntity.status(status).body(
@@ -66,12 +67,12 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.get")
     @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Any>> {
+    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<JsonNode>> {
         return getDocument.measure {
             return@measure try {
                 validerPath(path)
                 logger.info("Henter S3 dokument")
-                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path)?.let { mapJsonToAny(it) }, status = HttpStatus.OK.name))
+                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path)?.let { mapJsonToAny<JsonNode>(it) }, status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
                 val status = HttpStatus.valueOf(gcpEx.code)
                 ResponseEntity.status(status).body(
@@ -116,12 +117,11 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.delete")
     @DeleteMapping("/{path}")
-    fun deleteDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Unit>> {
+    fun deleteDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Boolean>> {
         return deleteDocument.measure {
             return@measure try {
                 validerPath(path)
-                storage.slett(path)
-                ResponseEntity.ok(FrontEndResponse(status = HttpStatus.OK.name))
+                ResponseEntity.ok(FrontEndResponse(result = storage.slett(path), status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
                 val status = HttpStatus.valueOf(gcpEx.code)
                 ResponseEntity.status(status).body(

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.api.storage
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.google.cloud.storage.StorageException
 import io.micrometer.core.annotation.Timed
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
@@ -7,6 +8,7 @@ import no.nav.eessi.pensjon.api.FrontEndResponse
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.services.auth.EessiPensjonTilgang
+import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.maskerPersonIdentifier
 import no.nav.security.token.support.core.api.Protected
 import org.slf4j.LoggerFactory
@@ -64,12 +66,12 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.get")
     @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<String>> {
+    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Any>> {
         return getDocument.measure {
             return@measure try {
                 validerPath(path)
                 logger.info("Henter S3 dokument")
-                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path), status = HttpStatus.OK.name))
+                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path)?.let { mapJsonToAny<Any>(it) }, status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
                 val status = HttpStatus.valueOf(gcpEx.code)
                 ResponseEntity.status(status).body(

--- a/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/storage/StorageController.kt
@@ -3,12 +3,12 @@ package no.nav.eessi.pensjon.api.storage
 import com.google.cloud.storage.StorageException
 import io.micrometer.core.annotation.Timed
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import no.nav.eessi.pensjon.api.FrontEndResponse
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.services.auth.EessiPensjonTilgang
-import no.nav.eessi.pensjon.utils.errorBody
+import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.maskerPersonIdentifier
-import no.nav.eessi.pensjon.utils.successBody
 import no.nav.security.token.support.core.api.Protected
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,19 +44,21 @@ class StorageController(private val storage: GcpStorageService,
     @Timed("s3.put")
     @PostMapping("/{path}")
     fun storeDocument(@PathVariable(required = true) path: String,
-                      @RequestBody(required = true) document: String): ResponseEntity<String>{
+                      @RequestBody(required = true) document: String): ResponseEntity<FrontEndResponse<Unit>> {
         return storeDocument.measure {
             return@measure try {
                 validerPath(path)
                 storage.lagre(path, document).also { logger.info("Lagrer dokument for frontend: $path") }
-                ResponseEntity.ok().body(successBody())
+                ResponseEntity.ok(FrontEndResponse(status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.valueOf(gcpEx.code)).body(errorBody(gcpEx.message, uuid))
+                val status = HttpStatus.valueOf(gcpEx.code)
+                ResponseEntity.status(status).body(
+                    FrontEndResponse(status = status.name, message = gcpEx.message)
+                )
             } catch (ex: Exception) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(errorBody("Klarte ikke å lagre s3 dokumenter", uuid))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    FrontEndResponse(status = HttpStatus.INTERNAL_SERVER_ERROR.name, message = "Klarte ikke å lagre s3 dokumenter")
+                )
             }
         }
     }
@@ -64,19 +66,21 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.get")
     @GetMapping(value = ["/get/{path}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<String> {
+    fun getDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Any>> {
         return getDocument.measure {
             return@measure try {
                 validerPath(path)
                 logger.info("Henter S3 dokument")
-                ResponseEntity.ok().body(storage.hent(path))
+                ResponseEntity.ok(FrontEndResponse(result = storage.hent(path)?.let { mapJsonToAny(it) }, status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.valueOf(gcpEx.code)).body(errorBody(gcpEx.message, uuid))
+                val status = HttpStatus.valueOf(gcpEx.code)
+                ResponseEntity.status(status).body(
+                    FrontEndResponse(status = status.name, message = gcpEx.message)
+                )
             } catch (ex: Exception) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(errorBody("Klarte ikke å hente s3 dokument", uuid))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    FrontEndResponse(status = HttpStatus.INTERNAL_SERVER_ERROR.name, message = "Klarte ikke å hente s3 dokument")
+                )
             }
         }
     }
@@ -84,26 +88,27 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.list")
     @GetMapping("/list")
-    fun listAll(): ResponseEntity<List<String>> {
+    fun listAll(): ResponseEntity<FrontEndResponse<List<String>>> {
         return listDocuments("")
     }
 
     @EessiPensjonTilgang
     @Timed("s3.list")
     @GetMapping("/list/{prefix}")
-    fun listDocuments(@PathVariable(required = true) prefix: String): ResponseEntity<List<String>> {
+    fun listDocuments(@PathVariable(required = true) prefix: String): ResponseEntity<FrontEndResponse<List<String>>> {
         return listDocuments.measure {
             return@measure try {
-                //validerPath(prefix)
                 logger.info("Lister S3 dokumenter")
-                ResponseEntity.ok().body(storage.list(prefix))
+                ResponseEntity.ok(FrontEndResponse(result = storage.list(prefix), status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.valueOf(gcpEx.code)).body(listOf(errorBody(gcpEx.message, uuid)))
+                val status = HttpStatus.valueOf(gcpEx.code)
+                ResponseEntity.status(status).body(
+                    FrontEndResponse(status = status.name, message = gcpEx.message)
+                )
             } catch (ex: Exception) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(listOf(errorBody("Klarte ikke å liste s3 dokumenter", uuid)))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    FrontEndResponse(status = HttpStatus.INTERNAL_SERVER_ERROR.name, message = "Klarte ikke å liste s3 dokumenter")
+                )
             }
         }
     }
@@ -111,19 +116,21 @@ class StorageController(private val storage: GcpStorageService,
     @EessiPensjonTilgang
     @Timed("s3.delete")
     @DeleteMapping("/{path}")
-    fun deleteDocument(@PathVariable(required = true) path: String): ResponseEntity<String> {
+    fun deleteDocument(@PathVariable(required = true) path: String): ResponseEntity<FrontEndResponse<Unit>> {
         return deleteDocument.measure {
             return@measure try {
                 validerPath(path)
                 storage.slett(path)
-                ResponseEntity.ok().body(successBody())
+                ResponseEntity.ok(FrontEndResponse(status = HttpStatus.OK.name))
             } catch (gcpEx: StorageException) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.valueOf(gcpEx.code)).body(errorBody(gcpEx.message, uuid))
+                val status = HttpStatus.valueOf(gcpEx.code)
+                ResponseEntity.status(status).body(
+                    FrontEndResponse(status = status.name, message = gcpEx.message)
+                )
             } catch (ex: Exception) {
-                val uuid = UUID.randomUUID().toString()
-                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(errorBody("Klarte ikke å slette s3 dokument", uuid))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    FrontEndResponse(status = HttpStatus.INTERNAL_SERVER_ERROR.name, message = "Klarte ikke å slette s3 dokument")
+                )
             }
         }
     }

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,15 +62,18 @@ class StorageControllerTest {
     // getDocument
 
     @Test
-    fun `getDocument happy path returns 200 with raw document as result`() {
-        val document = """{"rinaSakId":"123","bucs":[]}"""
-        every { gcpStorageService.hent(any()) } returns document
+    fun `getDocument happy path returns 200 with parsed JSON as result`() {
+        every { gcpStorageService.hent(any()) } returns """{"rinaSakId":"123","bucs":[]}"""
 
         val response = storageController.getDocument("12345678901___bucs")
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(HttpStatus.OK.name, response.body?.status)
-        assertEquals(document, response.body?.result)
+        assertNotNull(response.body?.result)
+        val result = response.body?.result
+        assert(result is Map<*, *>) { "Expected Map but got ${result?.javaClass}" }
+        @Suppress("UNCHECKED_CAST")
+        assertEquals("123", (result as Map<String, Any>)["rinaSakId"])
     }
 
     @Test

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
@@ -1,0 +1,139 @@
+package no.nav.eessi.pensjon.api.storage
+
+import com.google.cloud.storage.StorageException
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.api.FrontEndResponse
+import no.nav.eessi.pensjon.gcp.GcpStorageService
+import no.nav.eessi.pensjon.metrics.MetricsHelper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class StorageControllerTest {
+
+    private lateinit var gcpStorageService: GcpStorageService
+    private lateinit var storageController: StorageController
+
+    @BeforeEach
+    fun setUp() {
+        gcpStorageService = mockk(relaxed = true)
+        storageController = StorageController(gcpStorageService, MetricsHelper.ForTest())
+    }
+
+    // storeDocument
+
+    @Test
+    fun `storeDocument happy path returns 200 with status OK`() {
+        every { gcpStorageService.lagre(any(), any()) } returns Unit
+
+        val response = storageController.storeDocument("12345678901___bucs", """{"key":"value"}""")
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(HttpStatus.OK.name, response.body?.status)
+        assertNull(response.body?.result)
+    }
+
+    @Test
+    fun `storeDocument StorageException preserves GCP HTTP status`() {
+        val gcpEx = StorageException(403, "Forbidden")
+        every { gcpStorageService.lagre(any(), any()) } throws gcpEx
+
+        val response = storageController.storeDocument("12345678901___bucs", """{}""")
+
+        assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+        assertEquals(HttpStatus.FORBIDDEN.name, response.body?.status)
+        assertEquals("Forbidden", response.body?.message)
+    }
+
+    @Test
+    fun `storeDocument generic exception returns 500`() {
+        every { gcpStorageService.lagre(any(), any()) } throws RuntimeException("boom")
+
+        val response = storageController.storeDocument("12345678901___bucs", """{}""")
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.name, response.body?.status)
+        assertEquals("Klarte ikke å lagre s3 dokumenter", response.body?.message)
+    }
+
+    // getDocument
+
+    @Test
+    fun `getDocument happy path returns 200 with parsed JSON as result`() {
+        every { gcpStorageService.hent(any()) } returns """{"rinaSakId":"123","bucs":[]}"""
+
+        val response = storageController.getDocument("12345678901___bucs")
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(HttpStatus.OK.name, response.body?.status)
+        assertNotNull(response.body?.result)
+        // result is parsed JSON — should be a Map, not a raw String
+        val result = response.body?.result
+        assert(result is Map<*, *>) { "Expected Map but got ${result?.javaClass}" }
+        @Suppress("UNCHECKED_CAST")
+        assertEquals("123", (result as Map<String, Any>)["rinaSakId"])
+    }
+
+    @Test
+    fun `getDocument StorageException preserves GCP HTTP status`() {
+        val gcpEx = StorageException(404, "Not Found")
+        every { gcpStorageService.hent(any()) } throws gcpEx
+
+        val response = storageController.getDocument("12345678901___bucs")
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertEquals(HttpStatus.NOT_FOUND.name, response.body?.status)
+        assertEquals("Not Found", response.body?.message)
+    }
+
+    @Test
+    fun `getDocument generic exception returns 500`() {
+        every { gcpStorageService.hent(any()) } throws RuntimeException("oops")
+
+        val response = storageController.getDocument("12345678901___bucs")
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.name, response.body?.status)
+        assertEquals("Klarte ikke å hente s3 dokument", response.body?.message)
+    }
+
+    // listDocuments
+
+    @Test
+    fun `listDocuments happy path returns 200 with list in result`() {
+        every { gcpStorageService.list(any()) } returns listOf("12345678901___bucs", "12345678901___p5000")
+
+        val response = storageController.listDocuments("12345678901")
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(HttpStatus.OK.name, response.body?.status)
+        assertEquals(listOf("12345678901___bucs", "12345678901___p5000"), response.body?.result)
+    }
+
+    @Test
+    fun `listDocuments StorageException preserves GCP HTTP status`() {
+        val gcpEx = StorageException(503, "Service Unavailable")
+        every { gcpStorageService.list(any()) } throws gcpEx
+
+        val response = storageController.listDocuments("12345678901")
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.statusCode)
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.name, response.body?.status)
+        assertNull(response.body?.result)
+    }
+
+    @Test
+    fun `listDocuments generic exception returns 500`() {
+        every { gcpStorageService.list(any()) } throws RuntimeException("fail")
+
+        val response = storageController.listDocuments("12345678901")
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.name, response.body?.status)
+        assertEquals("Klarte ikke å liste s3 dokumenter", response.body?.message)
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
@@ -7,7 +7,6 @@ import no.nav.eessi.pensjon.api.FrontEndResponse
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -34,7 +33,7 @@ class StorageControllerTest {
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(HttpStatus.OK.name, response.body?.status)
-        assertNull(response.body?.result)
+        assertEquals(true, response.body?.result)
     }
 
     @Test
@@ -70,12 +69,8 @@ class StorageControllerTest {
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(HttpStatus.OK.name, response.body?.status)
-        assertNotNull(response.body?.result)
-        // result is parsed JSON — should be a Map, not a raw String
         val result = response.body?.result
-        assert(result is Map<*, *>) { "Expected Map but got ${result?.javaClass}" }
-        @Suppress("UNCHECKED_CAST")
-        assertEquals("123", (result as Map<String, Any>)["rinaSakId"])
+        assertEquals("123", result?.get("rinaSakId")?.asText())
     }
 
     @Test
@@ -135,5 +130,16 @@ class StorageControllerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.name, response.body?.status)
         assertEquals("Klarte ikke å liste s3 dokumenter", response.body?.message)
+    }
+
+    @Test
+    fun `deleteDocument happy path returns deletion result`() {
+        every { gcpStorageService.slett(any()) } returns true
+
+        val response = storageController.deleteDocument("12345678901___bucs")
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(HttpStatus.OK.name, response.body?.status)
+        assertEquals(true, response.body?.result)
     }
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/storage/StorageControllerTest.kt
@@ -3,7 +3,6 @@ package no.nav.eessi.pensjon.api.storage
 import com.google.cloud.storage.StorageException
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.eessi.pensjon.api.FrontEndResponse
 import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -62,15 +61,15 @@ class StorageControllerTest {
     // getDocument
 
     @Test
-    fun `getDocument happy path returns 200 with parsed JSON as result`() {
-        every { gcpStorageService.hent(any()) } returns """{"rinaSakId":"123","bucs":[]}"""
+    fun `getDocument happy path returns 200 with raw document as result`() {
+        val document = """{"rinaSakId":"123","bucs":[]}"""
+        every { gcpStorageService.hent(any()) } returns document
 
         val response = storageController.getDocument("12345678901___bucs")
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(HttpStatus.OK.name, response.body?.status)
-        val result = response.body?.result
-        assertEquals("123", result?.get("rinaSakId")?.asText())
+        assertEquals(document, response.body?.result)
     }
 
     @Test


### PR DESCRIPTION
Closes #143

Migrates StorageController responses to FrontEndResponse while retaining original HTTP error statuses. Stored JSON is parsed and nested in `result`.

Related UI change: navikt/eessi-pensjon-saksbehandling-ui#504. Deploy backend before frontend.